### PR TITLE
Fixed YahooLeagueLoader Bug With Tied Matchups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Added better type checking for validation
+- Fixed bug in YahooLeagueLoader that caused tied matchups to raise an exception
 
 ## [1.1.1]
 

--- a/leeger/league_loader/YahooLeagueLoader.py
+++ b/leeger/league_loader/YahooLeagueLoader.py
@@ -100,8 +100,12 @@ class YahooLeagueLoader(LeagueLoader):
                 teamB = self.__yahooTeamIdToTeamMap[yahooMatchup.team2.team_id]
                 teamBScore = yahooMatchup.teams.team[1].team_points.total
                 # figure out tiebreakers if there needs to be one
-                teamAHasTiebreaker = yahooMatchup.winner_team_key == yahooTeamA.team_key and yahooMatchup.is_tied == 0
-                teamBHasTiebreaker = yahooMatchup.winner_team_key == yahooTeamB.team_key and yahooMatchup.is_tied == 0
+                teamAHasTiebreaker = False
+                teamBHasTiebreaker = False
+                if yahooMatchup.is_tied == 0:
+                    # non-tied matchup
+                    teamAHasTiebreaker = yahooMatchup.winner_team_key == yahooTeamA.team_key
+                    teamBHasTiebreaker = yahooMatchup.winner_team_key == yahooTeamB.team_key
                 matchupType = self.__getMatchupType(yahooMatchup)
                 matchups.append(Matchup(teamAId=teamA.id,
                                         teamBId=teamB.id,


### PR DESCRIPTION
- Fixed bug in YahooLeagueLoader that caused tied matchups to raise an exception