### PR TITLE
- Fixed ESPN League Loader issue where teams with byes would cause championship matchups to count as playoff matchups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixed ESPN League Loader issue where teams with byes would cause championship matchups to count as playoff matchups
 - Team names are now counted as too similar within a Year if they have the same text minus whitespace and letter case
 - Package version updates
 - Added a Code of Conduct

--- a/leeger/league_loader/ESPNLeagueLoader.py
+++ b/leeger/league_loader/ESPNLeagueLoader.py
@@ -127,7 +127,7 @@ class ESPNLeagueLoader(LeagueLoader):
                     # this is the championship week
                     # figure out if this team has lost in the playoffs before this week
                     playoffOutcomes = espnTeam.outcomes[-numberOfPlayoffWeeks:-1]
-                    hasLostInPlayoffs = playoffOutcomes.count(self.__ESPN_WIN_OUTCOME) != len(playoffOutcomes)
+                    hasLostInPlayoffs = self.__ESPN_LOSS_OUTCOME in playoffOutcomes
                     if hasLostInPlayoffs:
                         return MatchupType.PLAYOFF
                     else:


### PR DESCRIPTION
- Fixed ESPN League Loader issue where teams with byes would cause championship matchups to count as playoff matchups
