### PR TITLE
Update MyFantasyLeague for playoff weeks

### DIFF
--- a/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
+++ b/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
@@ -43,9 +43,9 @@ class MyFantasyLeagueLeagueLoader(LeagueLoader):
         self.__mflLeagueIdToYearMap: dict[str, int] = dict()
         self.__mflFranchiseIdToOwnerMap: dict[str, Owner] = dict()
         self.__mflFranchiseIdToTeamMap: dict[int, Team] = dict()
-        self.__mflDivisionIdToDivisionMap: dict[
-            str, Division
-        ] = dict()  # holds the division info for ONLY the current year
+        self.__mflDivisionIdToDivisionMap: dict[str, Division] = (
+            dict()
+        )  # holds the division info for ONLY the current year
 
     def __getAllLeagues(self) -> list[dict]:
         mflLeagues: list[dict] = list()
@@ -157,7 +157,7 @@ class MyFantasyLeagueLeagueLoader(LeagueLoader):
                 break
             # Make sure that localMatchups is a list (some weeks just have a json element)
             if not (isinstance(local_matchups, list)):
-                 local_matchups = [local_matchups]
+                local_matchups = [local_matchups]
             for matchup in local_matchups:
                 teamAMFLFranchiseId = matchup["franchise"][0]["id"]
                 teamAId = self.__mflFranchiseIdToTeamMap[teamAMFLFranchiseId].id

--- a/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
+++ b/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
@@ -151,7 +151,14 @@ class MyFantasyLeagueLeagueLoader(LeagueLoader):
                 playoffsStarted = True
             # get each teams matchup for that week
             matchups = list()
-            for matchup in week["matchup"]:
+            # skip weeks with no matchup. get() is a safe method that doesn't throw an error if the element is missing.
+            local_matchups = week.get("matchup", {})
+            if not local_matchups:
+                break
+            # Make sure that localMatchups is a list (some weeks just have a json element)
+            if not (isinstance(local_matchups, list)):
+                 local_matchups = [local_matchups]
+            for matchup in local_matchups:
                 teamAMFLFranchiseId = matchup["franchise"][0]["id"]
                 teamAId = self.__mflFranchiseIdToTeamMap[teamAMFLFranchiseId].id
                 teamAScore = float(matchup["franchise"][0]["score"])

--- a/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
+++ b/leeger/league_loader/MyFantasyLeagueLeagueLoader.py
@@ -43,9 +43,9 @@ class MyFantasyLeagueLeagueLoader(LeagueLoader):
         self.__mflLeagueIdToYearMap: dict[str, int] = dict()
         self.__mflFranchiseIdToOwnerMap: dict[str, Owner] = dict()
         self.__mflFranchiseIdToTeamMap: dict[int, Team] = dict()
-        self.__mflDivisionIdToDivisionMap: dict[str, Division] = (
-            dict()
-        )  # holds the division info for ONLY the current year
+        self.__mflDivisionIdToDivisionMap: dict[
+            str, Division
+        ] = dict()  # holds the division info for ONLY the current year
 
     def __getAllLeagues(self) -> list[dict]:
         mflLeagues: list[dict] = list()


### PR DESCRIPTION
**Summary:**

- Corrects the situation where a MyFantasyLeague weekly schedule has a single matchup (championship week) by converting the matchup element to a list[] like the other weeks.

- Corrects the situation where matchups is missing (skipped week) by breaking the week loop. (This might be better if it just skipped the rest of the code and continued to the next week to account for skipped weeks other than the final week.)

**Testing**
All tests pass 100%
(Didn't create any new tests, sorry.)

**Background:**
@joeyagreco When I was testing Leeger with MyFantasyLeague I found that it received errors in week 17 (championship) and 18 (skipped) of my league data. That's because the schedule object is a bit different than the rest of the weeks:

**Weeks 1-16** - matchup is a list[] of matchups
`"schedule": {
"weeklySchedule": {
"week": "16",
"matchup": [
{
"franchise": [
{...`

**Week 17** - matchup is a single matchup element
`"schedule": {
"weeklySchedule": {
"week": "17",
"matchup": {
"franchise": [...
}
},`

**Week 18** - no matchup element for a skipped week
`"schedule": {
"weeklySchedule": {
"week": "18"
}
},`
