### PR TITLE
Bump espn_api to 0.37.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-espn_api~=0.34.0
+espn_api~=0.37.0
 fleaflicker~=1.0.0
 numpy~=1.24.4
 openpyxl~=3.1.2


### PR DESCRIPTION
Includes a fix to espn api endpoint and added line up spot
https://github.com/cwendt94/espn-api/releases/tag/v0.36.0
https://github.com/cwendt94/espn-api/pull/540